### PR TITLE
Readme update and small fix to image loading

### DIFF
--- a/namo/utils/infer_utils.py
+++ b/namo/utils/infer_utils.py
@@ -3,6 +3,7 @@ from PIL import Image
 import base64
 from threading import Thread
 import io
+import os
 from transformers import TextStreamer
 
 try:
@@ -12,6 +13,8 @@ except ImportError:
 
 
 def load_image(image_file):
+    if isinstance(image_file, Image.Image):
+        return image_file
     if image_file.startswith("http") or image_file.startswith("https"):
         response = requests.get(image_file)
         image = Image.open(io.BytesIO(response.content)).convert("RGB")
@@ -21,7 +24,9 @@ def load_image(image_file):
 
 
 def load_multi_images_maybe(image_files, splitter=" "):
-    if isinstance(image_files, str):
+    if isinstance(image_files, Image.Image):
+        return [image_files]
+    if isinstance(image_files, str) and not os.path.exists(image_files):
         images = image_files.split(splitter)
     else:
         images = image_files

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ pip install -U namo
 A simple demo would be:
 
 ```python
+import torch
 from namo.api.vl import VLInfer
 
 # model will download automatically
@@ -76,6 +77,7 @@ model = VLInfer(
 )
 
 # default will have streaming
+# this method accepts a single path or PIL image, or an array of same.
 model.generate(images='images/cats.jpg', prompt='what is this?')
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ model = VLInfer(
 )
 
 # default will have streaming
-# this method accepts a single path or PIL image, or an array of same.
+# this method accepts a single path, url, or PIL image, or an array of same.
 model.generate(images='images/cats.jpg', prompt='what is this?')
 ```
 


### PR DESCRIPTION
- The example on the readme needs `import torch` to work (for the `cuda.is_available()` call)
- Fixed an issue where a single image with a space in the name would be treated as 2 paths. (Suggest maybe changing the auto-splitter to something else in future)
- Users can now call generate providing instances of PIL images directly (single or array).